### PR TITLE
add lz flag in sntool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,4 +59,4 @@ build/macdylibbundler: 3rdparty/macdylibbundler/*
 	@$(MAKE) -C $(<D)
 
 bin/sntool: sntool/sntool.cpp
-	@$(CROSS_COMPILE)g++ -I3rdparty/sunxi-tools -I3rdparty/mkbootimg -std=gnu++11 -Wall -Wextra $< -o $@
+	@$(CROSS_COMPILE)g++ -I3rdparty/sunxi-tools -I3rdparty/mkbootimg -lz -std=gnu++11 -Wall -Wextra $< -o $@


### PR DESCRIPTION
During the sntool build process, it shows error `undefined reference to crc32`
Adding -lz in g++ call in Makefile, the problem is solved